### PR TITLE
Make bridgehead css more selective

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -192,6 +192,11 @@ p span.i16{
 	text-indent: 0;
 }
 
+[epub|type~="z3998:poem"] [epub|type~="bridgehead"],
+[epub|type~="z3998:hymn"] [epub|type~="bridgehead"]{
+	text-align: justify;
+}
+
 [epub|type~="bridgehead"] i{
 	font-style: normal;
 }


### PR DESCRIPTION
Ok, so the last PR actually _did_ do something... just not for the reason I initially thought. There actually was a problem with the bridgeheads not being centered, because the css for poems that sets `text-align` to `initial` was more selective than the bridgehead css that set `text-align` to `justify`. You can see this in action in the following screenshots.

This is the bridgehead before the fix. You can see that `text-align` is set to `initial`.

![Screenshot from 2021-01-31 16-23-41](https://user-images.githubusercontent.com/1240463/106402995-32712780-63e1-11eb-83d6-956d810b60ba.png)

Now this is the bridgehead with the fix:

![Screenshot from 2021-01-31 16-10-38](https://user-images.githubusercontent.com/1240463/106403046-6a786a80-63e1-11eb-9db5-644cd8a041e8.png)

With the more selective CSS, it ensures that `text-align` is properly set to `justify`.