### PR TITLE
Tweak semantics

### DIFF
--- a/src/epub/text/dedication.xhtml
+++ b/src/epub/text/dedication.xhtml
@@ -28,7 +28,7 @@
 				<p epub:type="se:letter.dateline">
 					<b>The Oratory,</b>
 					<br/>
-					<time datetime="1867-12-21"><em>December</em> 21, 1867.</time>
+					<time datetime="1867-12-21"><i>December</i> 21, 1867.</time>
 				</p>
 			</footer>
 		</section>

--- a/src/epub/text/verses-on-various-occasions.xhtml
+++ b/src/epub/text/verses-on-various-occasions.xhtml
@@ -7917,10 +7917,10 @@
 					<h2 epub:type="ordinal z3998:roman">CXXXIX</h2>
 					<h3 epub:type="title">Prime</h3>
 				</hgroup>
-				<blockquote epub:type="epigraph">
+				<div epub:type="bridgehead">
 					<p xml:lang="la">Jam lucis orto sidere.</p>
-					<cite>(From the Parisian Breviary.<a href="endnotes.xhtml#note-14" id="noteref-14" epub:type="noteref">14</a>)</cite>
-				</blockquote>
+					<p>(From the Parisian Breviary.<a href="endnotes.xhtml#note-14" id="noteref-14" epub:type="noteref">14</a>)</p>
+				</div>
 			</header>
 			<p>
 				<span>Now that the day-star glimmers bright,</span>


### PR DESCRIPTION
I think the way I semanticated "Prime" (and the way that was fixed for the final production) was misleading. I don't think "Jam lucis orto sidere" is an epigraph, but it's the first words of the hymn in the original Latin. I don't think that "From the Parisian Breviary" is a citation for a quote as much as it is part of the bridgehead with "Jam lucis orto sidere" since they are both descriptions of the entire hymn.